### PR TITLE
go1.18以上版本通过go list -m -f xxx 方式会受go.work影响获取不到正确的文件路径 导致产生 exit stat…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,6 @@ require (
 
 require (
 	github.com/google/go-cmp v0.5.7 // indirect
+	github.com/hashicorp/go-version v1.7.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
+github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/util/dir.go
+++ b/util/dir.go
@@ -18,13 +18,26 @@
 package util
 
 import (
+	"path/filepath"
 	"strings"
 )
 
 func GetModuleDir() (string, error) {
-	output, err := Exec("go list -m -f '{{.Dir}}'", "./")
-	if err != nil {
-		output, err = Exec("go list -m -f '{{.Module.Dir}}'", "./")
+	var (
+		output string
+		err    error
+	)
+	if IsVersionGreaterThan118() {
+		output, err = Exec("go env GOMOD", "./")
+		if err != nil {
+			return "", err
+		}
+		output = filepath.Dir(output)
+	} else {
+		output, err = Exec("go list -m -f '{{.Dir}}'", "./")
+		if err != nil {
+			output, err = Exec("go list -m -f '{{.Module.Dir}}'", "./")
+		}
 	}
 
 	if err != nil {

--- a/util/version.go
+++ b/util/version.go
@@ -1,0 +1,19 @@
+// @Package: util
+// @Author: linfuchuan
+// @Date: 2024/7/4 20:40
+
+package util
+
+import (
+	"github.com/hashicorp/go-version"
+	"runtime"
+)
+
+// IsVersionGreaterThan118
+// @Description: 是否运行时go版本大于1.18
+// @return bool
+func IsVersionGreaterThan118() bool {
+	version1_18, _ := version.NewVersion("1.18")
+	v, _ := version.NewVersion(runtime.Version()[2:])
+	return v.GreaterThanOrEqual(version1_18)
+}


### PR DESCRIPTION
## 说明
1.18以上版本通过go list -m -f '{{.Dir}}' 方式会受`go.work`影响获取不到正确的文件路径,导致产生 `exit status 127` 错误

本次通过对go版本进行判断 高于1.18版本 通过go env GOMOD获取 module path

